### PR TITLE
Match colour channel to wavelength in sample.txt

### DIFF
--- a/optimisation/settings/sample.txt
+++ b/optimisation/settings/sample.txt
@@ -16,7 +16,7 @@
                      "image filename"        : "../dataset/test/images/couch_rgb.png",
                      "depth filename"        : "../dataset/test/depths/couch_rgb.png",
                      "scheme"                : "defocus",
-                     "color channel"         : 0,
+                     "color channel"         : 1,
                      "defocus blur size"     : 10,
                      "blur ratio"            : 0.25,
                      "number of planes"      : 6,


### PR DESCRIPTION
Set both the wavelength and the colour channel to green as they are not currently matching: red channel (0) and green wavelength (0.000000515).